### PR TITLE
Handle PathResolver better

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,10 @@
         "composer/ca-bundle": "^1.0",
         "symfony/requirements-checker": "^1.0"
     },
+    "require-dev": {
+        "bolt/bolt": "^3.4",
+        "passwordlib/passwordlib": "^1.0@beta"
+    },
     "bin": [
         "bin/bolt-requirements"
     ],


### PR DESCRIPTION
- Allow `PathResolver` to be passed in
- Grab `PathResolver` from `Bootstrap`ped application if it isn't passed in
- Skip path checks if `PathResolver` is not given or cannot be created

Depends on #4